### PR TITLE
Allow extending SecurityChecker

### DIFF
--- a/PostProcessing/Processor/Security/SecurityChecker.php
+++ b/PostProcessing/Processor/Security/SecurityChecker.php
@@ -105,7 +105,7 @@ class SecurityChecker
      * @param Request $request
      * @return array
      */
-    private function getVariables (Request $request) : array
+    protected function getVariables (Request $request) : array
     {
         $token = $this->tokenStorage->getToken();
 


### PR DESCRIPTION
It should be possible that implementing apps can inject their own variables, so (custom) expressions can use them