### PR TITLE
Remove request attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 =====
 
 *   Removed automatically fetching attributes from the request (less magic is better).
+*   Add option to set tree parameters when rendering a tree.
 
 
 4.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.1.0
+=====
+
+*   Removed automatically fetching attributes from the request (less magic is better).
+
+
 4.0.1
 =====
 

--- a/src/Parameter/ParametersMerger.php
+++ b/src/Parameter/ParametersMerger.php
@@ -5,26 +5,10 @@ namespace Becklyn\RouteTreeBundle\Parameter;
 use Becklyn\Menu\Item\MenuItem;
 use Becklyn\Menu\Target\LazyRoute;
 use Becklyn\RouteTreeBundle\Exception\InvalidParameterValueException;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class ParametersMerger
 {
     public const VARIABLES_EXTRA_KEY = "_route_tree.path_vars";
-
-
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-
-    /**
-     * @param RequestStack $requestStack
-     */
-    public function __construct (RequestStack $requestStack)
-    {
-        $this->requestStack = $requestStack;
-    }
 
 
     /**
@@ -38,12 +22,7 @@ class ParametersMerger
      */
     public function mergeParameters (MenuItem $item, array $parameters, array $routeSpecificParameters = []) : void
     {
-        $request = $this->requestStack->getMasterRequest();
-        $requestParameters = null !== $request
-            ? $request->attributes->all()
-            : [];
-
-        $this->traverse($item, $routeSpecificParameters, $parameters, $requestParameters);
+        $this->traverse($item, $routeSpecificParameters, $parameters);
     }
 
 
@@ -51,15 +30,13 @@ class ParametersMerger
      * @param MenuItem $item
      * @param array    $routeSpecificParameters
      * @param array    $parameters
-     * @param array    $requestParameters
      *
      * @throws InvalidParameterValueException
      */
     private function traverse (
         MenuItem $item,
         array $routeSpecificParameters,
-        array $parameters,
-        array $requestParameters
+        array $parameters
     ) : void
     {
         $target = $item->getTarget();
@@ -76,7 +53,6 @@ class ParametersMerger
                     $itemParameters,
                     $routeSpecificParameters[$target->getRoute()] ?? [],
                     $parameters,
-                    $requestParameters,
                 ];
 
                 foreach ($sources as $source)
@@ -105,7 +81,7 @@ class ParametersMerger
 
         foreach ($item->getChildren() as $child)
         {
-            $this->traverse($child, $routeSpecificParameters, $parameters, $requestParameters);
+            $this->traverse($child, $routeSpecificParameters, $parameters);
         }
     }
 

--- a/src/Twig/RouteTreeTwigExtension.php
+++ b/src/Twig/RouteTreeTwigExtension.php
@@ -50,10 +50,12 @@ class RouteTreeTwigExtension extends AbstractExtension
     /**
      * Renders the tree.
      *
-     * @param string $fromRoute
-     * @param array  $renderOptions
+     * @param string $fromRoute       the route to start the rendering from
      * @param array  $renderOptions   the options for rendering
+     * @param array  $parameters      the global parameters to use when resolving the parameters
      * @param array  $routeParameters the route-specific parameters to use when resolving the parameters
+     *
+     * @throws InvalidParameterValueException
      *
      * @return string
      */
@@ -76,8 +78,8 @@ class RouteTreeTwigExtension extends AbstractExtension
      * Builds and renders a breadcrumb.
      *
      * @param string $fromRoute       the route to start the rendering from
-     * @param array  $parameters      the global parameters to use when resolving the parameters
      * @param array  $renderOptions   the options for rendering
+     * @param array  $parameters      the global parameters to use when resolving the parameters
      * @param array  $routeParameters the route-specific parameters to use when resolving the parameters
      *
      * @throws InvalidParameterValueException

--- a/src/Twig/RouteTreeTwigExtension.php
+++ b/src/Twig/RouteTreeTwigExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Becklyn\RouteTreeBundle\Twig;
 
 use Becklyn\Menu\Renderer\MenuRenderer;
+use Becklyn\RouteTreeBundle\Exception\InvalidParameterValueException;
 use Becklyn\RouteTreeBundle\Menu\MenuBuilder;
 use Becklyn\RouteTreeBundle\Parameter\ParametersMerger;
 use Twig\Extension\AbstractExtension;
@@ -51,10 +52,12 @@ class RouteTreeTwigExtension extends AbstractExtension
      *
      * @param string $fromRoute
      * @param array  $renderOptions
+     * @param array  $renderOptions   the options for rendering
+     * @param array  $routeParameters the route-specific parameters to use when resolving the parameters
      *
      * @return string
      */
-    public function renderTree (string $fromRoute, array $renderOptions = []) : string
+    public function renderTree (string $fromRoute, array $renderOptions = [], array $parameters = [], array $routeParameters = []) : string
     {
         $root = $this->menuBuilder->build($fromRoute);
 
@@ -64,6 +67,7 @@ class RouteTreeTwigExtension extends AbstractExtension
             unset($renderOptions["rootClass"]);
         }
 
+        $this->parameterMerger->mergeParameters($root, $parameters, $routeParameters);
         return $this->menuRenderer->render($root, $renderOptions);
     }
 
@@ -76,7 +80,7 @@ class RouteTreeTwigExtension extends AbstractExtension
      * @param array  $renderOptions   the options for rendering
      * @param array  $routeParameters the route-specific parameters to use when resolving the parameters
      *
-     * @throws \Becklyn\RouteTreeBundle\Exception\InvalidParameterValueException
+     * @throws InvalidParameterValueException
      *
      * @return string
      */

--- a/tests/Parameters/ParameterMergerTest.php
+++ b/tests/Parameters/ParameterMergerTest.php
@@ -32,7 +32,6 @@ class ParameterMergerTest extends TestCase
                 ["abc" => 5], // item
                 [], // route specific
                 [], // defaults
-                [], // request
                 ["abc" => 5], // expected
             ],
             "route specific only" => [
@@ -40,7 +39,6 @@ class ParameterMergerTest extends TestCase
                 [], // item
                 ["example.route" => ["abc" => 5]], // route specific
                 [], // defaults
-                [], // request
                 ["abc" => 5], // expected
             ],
             "defaults only" => [
@@ -48,15 +46,6 @@ class ParameterMergerTest extends TestCase
                 [], // item
                 [], // route specific
                 ["abc" => 5], // defaults
-                [], // request
-                ["abc" => 5], // expected
-            ],
-            "request only" => [
-                ["abc"], // variables
-                [], // item
-                [], // route specific
-                [], // defaults
-                ["abc" => 5], // request
                 ["abc" => 5], // expected
             ],
             "nothing" => [
@@ -64,7 +53,6 @@ class ParameterMergerTest extends TestCase
                 [], // item
                 [], // route specific
                 [], // defaults
-                [], // request
                 ["abc" => null], // expected
             ],
             "item most specific" => [
@@ -72,7 +60,6 @@ class ParameterMergerTest extends TestCase
                 ["abc" => 1], // item
                 ["example.route" => ["abc" => 2]], // route specific
                 ["abc" => 3], // defaults
-                ["abc" => 4], // request
                 ["abc" => 1], // expected
             ],
             "route most specific" => [
@@ -80,7 +67,6 @@ class ParameterMergerTest extends TestCase
                 [], // item
                 ["example.route" => ["abc" => 2]], // route specific
                 ["abc" => 3], // defaults
-                ["abc" => 4], // request
                 ["abc" => 2], // expected
             ],
             "defaults most specific" => [
@@ -88,30 +74,17 @@ class ParameterMergerTest extends TestCase
                 [], // item
                 [], // route specific
                 ["abc" => 3], // defaults
-                ["abc" => 4], // request
                 ["abc" => 3], // expected
-            ],
-            "request most specific" => [
-                ["abc"], // variables
-                [], // item
-                [], // route specific
-                [], // defaults
-                ["abc" => 4], // request
-                ["abc" => 4], // expected
             ],
             "different route" => [
                 ["abc"], // variables
                 [], // item
                 ["other" => ["abc" => 5]], // route specific
                 [], // defaults
-                [], // request
                 ["abc" => null], // expected
             ],
             "object with id route" => [
                 ["abc"], // variables
-                [], // item
-                [], // route specific
-                [], // defaults
                 [
                     "abc" => new class {
                         public function getId()
@@ -119,7 +92,9 @@ class ParameterMergerTest extends TestCase
                             return 123;
                         }
                     },
-                ], // request
+                ], // item
+                [], // route specific
+                [], // defaults
                 ["abc" => 123], // expected
             ],
         ];
@@ -133,7 +108,6 @@ class ParameterMergerTest extends TestCase
      * @param array $itemParameters
      * @param array $routeSpecificParameters
      * @param array $defaultParameters
-     * @param array $requestParameters
      * @param array $expected
      *
      * @throws \Becklyn\RouteTreeBundle\Exception\InvalidParameterValueException
@@ -143,7 +117,6 @@ class ParameterMergerTest extends TestCase
         array $itemParameters,
         array $routeSpecificParameters,
         array $defaultParameters,
-        array $requestParameters,
         array $expected
     ) : void
     {
@@ -155,7 +128,7 @@ class ParameterMergerTest extends TestCase
             ],
         ]);
 
-        $this->createParametersMerger($requestParameters)->mergeParameters($item, $defaultParameters, $routeSpecificParameters);
+        $this->createParametersMerger()->mergeParameters($item, $defaultParameters, $routeSpecificParameters);
         self::assertEquals($expected, $item->getTarget()->getParameters());
     }
 
@@ -198,18 +171,8 @@ class ParameterMergerTest extends TestCase
      *
      * @return ParametersMerger
      */
-    private function createParametersMerger (array $requestAttributes = []) : ParametersMerger
+    private function createParametersMerger () : ParametersMerger
     {
-        $requestStack = $this->getMockBuilder(RequestStack::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $request = new Request([], [], $requestAttributes);
-
-        $requestStack
-            ->method("getMasterRequest")
-            ->willReturn($request);
-
-        return new ParametersMerger($requestStack);
+        return new ParametersMerger();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | yes <!-- improves an existing feature, not adding a new one --> 
| New feature?  | yes <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | debatable
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | **missing** <!-- insert URL here -->

<!-- describe your changes below -->
The removal of the automatic request attributes fetching can technically be a BC break, but that was so fragile, that probably nobody ever used it. Passing these parameters explicitly instead is the way better option.